### PR TITLE
Parse not success model server http response as model error

### DIFF
--- a/nah/src/chat.rs
+++ b/nah/src/chat.rs
@@ -228,58 +228,60 @@ impl ChatContext {
    */
   pub fn generate(&mut self) -> Result<&ChatMessage, NahError> {
     let req_stream = self.get_generate_request(true);
-    let message: Result<Result<ChatMessage, NahError>, reqwest::Error> =
-      self.tokio_runtime.block_on(async {
-        let mut res = req_stream.send().await?;
-        if !res.status().is_success() {
-          let code = res.status().as_u16();
-          return Ok(Err(NahError::model_error(
-            &self.model_config.model,
-            &format!("Model server responds an error, HTTP Status = {}", code),
-          )));
-        }
-        let mut message = ChatMessage {
-          role: "".to_owned(),
-          content: "".to_owned(),
-          tool_call_id: None,
-          tool_calls: None,
+    let message: Result<ChatMessage, NahError> = self.tokio_runtime.block_on(async {
+      let mut res = match req_stream.send().await {
+        Ok(r) => r,
+        Err(_e) => return Err(NahError::model_invalid_response(&self.model_config.model)),
+      };
+      if !res.status().is_success() {
+        let code = res.status().as_u16();
+        return Err(NahError::model_error(
+          &self.model_config.model,
+          &format!("Model server responded with error: HTTP status {}", code),
+        ));
+      }
+      let mut message = ChatMessage {
+        role: "".to_owned(),
+        content: "".to_owned(),
+        tool_call_id: None,
+        tool_calls: None,
+      };
+      let mut reach_done = false;
+      let mut chunk_received = 0usize;
+      print!("Model is responding ...");
+      let _ = std::io::stdout().flush();
+      while !reach_done {
+        let chunk = match res.chunk().await {
+          Ok(Some(chunk)) => chunk,
+          Ok(None) => continue,
+          Err(_e) => return Err(NahError::model_invalid_response(&self.model_config.model)),
         };
-        let mut reach_done = false;
-        let mut chunk_received = 0usize;
-        print!("Model is responding ...");
-        let _ = std::io::stdout().flush();
-        while !reach_done {
-          let chunk = match res.chunk().await? {
-            Some(chunk) => chunk,
-            None => continue,
-          };
-          let delta = self.get_model_response_chunk(chunk);
-          match delta {
-            Some(ChatResponseChunk::Delta(d)) => {
-              self.apply_model_response_chunk(&mut message, d);
-              chunk_received += 1;
-              print!(
-                "\rModel is responding ... {} chunks received.",
-                chunk_received
-              );
-              let _ = std::io::stdout().flush();
-            }
-            Some(ChatResponseChunk::Done) => {
-              reach_done = true;
-              println!("\nModel finished generation!");
-            }
-            None => {}
+        let delta = self.get_model_response_chunk(chunk);
+        match delta {
+          Some(ChatResponseChunk::Delta(d)) => {
+            self.apply_model_response_chunk(&mut message, d);
+            chunk_received += 1;
+            print!(
+              "\rModel is responding ... {} chunks received.",
+              chunk_received
+            );
+            let _ = std::io::stdout().flush();
           }
+          Some(ChatResponseChunk::Done) => {
+            reach_done = true;
+            println!("\nModel finished generation!");
+          }
+          None => {}
         }
-        Ok(Ok(message))
-      });
+      }
+      Ok(message)
+    });
 
     match message {
-      Ok(Ok(msg)) => {
+      Ok(msg) => {
         self.messages.push(msg);
         Ok(&self.messages[self.messages.len() - 1])
       }
-      Ok(Err(e)) => Err(e),
       Err(_e) => Err(NahError::model_invalid_response(&self.model_config.model)),
     }
   }


### PR DESCRIPTION
As title. If the model server returns a response with code >=300, a model error will be returned with the HTTP status code as part of the message.