### PR TITLE
Support both string and number id values

### DIFF
--- a/nah/src/mcp/local_server.rs
+++ b/nah/src/mcp/local_server.rs
@@ -98,7 +98,7 @@ impl MCPServer for MCPLocalServerProcess {
   ) -> Result<MCPPromptResult, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
     let request = MCPRequest::get_prompt(
-      &id,
+      &Value::String(id),
       prompt_name,
       args.into_iter().map(|(k, v)| (k.as_str(), v.as_str())),
     );
@@ -209,8 +209,11 @@ impl MCPLocalServerProcess {
       history_file,
     };
 
-    let initialize_request =
-      MCPRequest::initialize(&uuid::Uuid::new_v4().to_string(), "nah", "0.1");
+    let initialize_request = MCPRequest::initialize(
+      &Value::String(uuid::Uuid::new_v4().to_string()),
+      "nah",
+      "0.1",
+    );
     let response: MCPResponse = result.send_and_wait_for_response(initialize_request)?;
     let initialized_notification = MCPNotification::initialized();
     result.send_data(initialized_notification)?;

--- a/nah/src/mcp/mod.rs
+++ b/nah/src/mcp/mod.rs
@@ -74,7 +74,7 @@ pub trait MCPServer {
    */
   fn fetch_tools(&mut self) -> Result<Vec<&MCPToolDefinition>, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
-    let request = MCPRequest::tools_list(&id);
+    let request = MCPRequest::tools_list(&Value::String(id));
     let response = self.send_and_wait_for_response(request)?;
 
     let tool_list = parse_tools_list_from_response(self.get_server_name(), response)?;
@@ -91,7 +91,7 @@ pub trait MCPServer {
    */
   fn call_tool(&mut self, tool_name: &str, args: &Value) -> Result<Value, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
-    let request = MCPRequest::tools_call(&id, tool_name, args);
+    let request = MCPRequest::tools_call(&Value::String(id), tool_name, args);
     let response = self.send_and_wait_for_response(request)?;
 
     match response.result {
@@ -124,7 +124,7 @@ pub trait MCPServer {
    */
   fn fetch_resources_list(&mut self) -> Result<Vec<&MCPResourceDefinition>, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
-    let request = MCPRequest::resources_list(&id);
+    let request = MCPRequest::resources_list(&Value::String(id));
     let response = self.send_and_wait_for_response(request)?;
     match response.result {
       Some(res) => {
@@ -161,7 +161,7 @@ pub trait MCPServer {
    */
   fn fetch_resource_templates_list(&mut self) -> Result<Vec<MCPResourceDefinition>, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
-    let request = MCPRequest::resource_templates_list(&id);
+    let request = MCPRequest::resource_templates_list(&Value::String(id));
     let response = self.send_and_wait_for_response(request)?;
     match response.result {
       Some(res) => {
@@ -212,7 +212,7 @@ pub trait MCPServer {
    */
   fn read_resources(&mut self, uri: &str) -> Result<Vec<MCPResourceContent>, NahError> {
     let id = uuid::Uuid::new_v4().to_string();
-    let request = MCPRequest::resources_read(&id, uri);
+    let request = MCPRequest::resources_read(&Value::String(id), uri);
     let response = self.send_and_wait_for_response(request)?;
     let contents = match response
       .result
@@ -248,7 +248,7 @@ pub trait MCPServer {
    */
   fn fetch_prompts_list(&mut self) -> Result<Vec<&MCPPromptDefinition>, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
-    let request = MCPRequest::prompts_list(&id);
+    let request = MCPRequest::prompts_list(&Value::String(id));
     let response = self.send_and_wait_for_response(request)?;
 
     let result = match response.result {
@@ -318,7 +318,7 @@ pub trait MCPServer {
   ) -> Result<MCPPromptResult, NahError> {
     let id: String = uuid::Uuid::new_v4().to_string();
     let request = MCPRequest::get_prompt(
-      &id,
+      &Value::String(id),
       prompt_name,
       args.into_iter().map(|(k, v)| (k.as_str(), v.as_str())),
     );

--- a/nah_mcp_types/src/lib.rs
+++ b/nah_mcp_types/src/lib.rs
@@ -14,13 +14,15 @@ use serde_json::Value;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MCPResponse {
   jsonrpc: String,
-  pub id: String,
+  pub id: Value,
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub result: Option<Value>,
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub error: Option<Value>,
 }
 
 impl MCPResponse {
-  pub fn new(id: String, result: Option<Value>, error: Option<Value>) -> MCPResponse {
+  pub fn new(id: Value, result: Option<Value>, error: Option<Value>) -> MCPResponse {
     MCPResponse {
       jsonrpc: "2.0".to_string(),
       id,

--- a/nah_mcp_types/src/request.rs
+++ b/nah_mcp_types/src/request.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 pub struct MCPRequest {
   jsonrpc: String,
   pub method: String,
-  pub id: String,
+  pub id: Value,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub params: Option<Value>,
 }
@@ -21,7 +21,7 @@ impl MCPRequest {
   /**
    * Request to initialize the server.
    */
-  pub fn initialize(id: &str, client_name: &str, client_version: &str) -> Self {
+  pub fn initialize(id: &Value, client_name: &str, client_version: &str) -> Self {
     let params = Some(json!({
         "protocolVersion": "2024-11-05",
         "capabilities": json!({}),
@@ -33,7 +33,7 @@ impl MCPRequest {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "initialize".to_string(),
-      id: id.to_string(),
+      id: id.clone(),
       params,
     }
   }
@@ -41,11 +41,11 @@ impl MCPRequest {
   /**
    * Request to fetch the list of available tools from `tools/list`.
    */
-  pub fn tools_list(id: &str) -> Self {
+  pub fn tools_list(id: &Value) -> Self {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "tools/list".to_string(),
-      id: id.to_string(),
+      id: id.clone(),
       params: None,
     }
   }
@@ -53,11 +53,11 @@ impl MCPRequest {
   /**
    * Request to call a tool.
    */
-  pub fn tools_call(id: &str, tool_name: &str, args: &Value) -> Self {
+  pub fn tools_call(id: &Value, tool_name: &str, args: &Value) -> Self {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "tools/call".to_string(),
-      id: id.to_string(),
+      id: id.clone(),
       params: Some(json!(
         {
         "name": tool_name,
@@ -70,11 +70,11 @@ impl MCPRequest {
   /**
    * Request to fetch the list of available resources from `resources/list`.
    */
-  pub fn resources_list(id: &str) -> Self {
+  pub fn resources_list(id: &Value) -> Self {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "resources/list".to_owned(),
-      id: id.to_string(),
+      id: id.clone(),
       params: None,
     }
   }
@@ -82,11 +82,11 @@ impl MCPRequest {
   /**
    * Request to fetch the list of available resource templates from `resources/templates/list`
    */
-  pub fn resource_templates_list(id: &str) -> Self {
+  pub fn resource_templates_list(id: &Value) -> Self {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "resources/templates/list".to_owned(),
-      id: id.to_string(),
+      id: id.clone(),
       params: None,
     }
   }
@@ -94,11 +94,11 @@ impl MCPRequest {
   /**
    * Request to read a resource.
    */
-  pub fn resources_read(id: &str, uri: &str) -> Self {
+  pub fn resources_read(id: &Value, uri: &str) -> Self {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "resources/read".to_owned(),
-      id: id.to_string(),
+      id: id.clone(),
       params: Some(json!(
       {
         "uri": uri.to_string()
@@ -109,11 +109,11 @@ impl MCPRequest {
   /**
    * Request to fetch available prompts.
    */
-  pub fn prompts_list(id: &str) -> Self {
+  pub fn prompts_list(id: &Value) -> Self {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "prompts/list".to_owned(),
-      id: id.to_owned(),
+      id: id.clone(),
       params: None,
     }
   }
@@ -121,7 +121,7 @@ impl MCPRequest {
   /**
    * Requeset to retrieve a prompt.
    */
-  pub fn get_prompt<'a, I>(id: &str, prompt_name: &str, args: I) -> Self
+  pub fn get_prompt<'a, I>(id: &Value, prompt_name: &str, args: I) -> Self
   where
     I: Iterator<Item = (&'a str, &'a str)>,
   {
@@ -132,7 +132,7 @@ impl MCPRequest {
     MCPRequest {
       jsonrpc: "2.0".to_string(),
       method: "prompts/get".to_owned(),
-      id: id.to_owned(),
+      id: id.clone(),
       params: Some(json!({
         "name": Value::String(prompt_name.to_owned()),
         "arguments": if arguments.len() > 0 { Some(Value::Object(arguments))} else {None}

--- a/nah_server/src/process_routine.rs
+++ b/nah_server/src/process_routine.rs
@@ -14,7 +14,7 @@ pub fn process_initialize<T>(server: &mut T, request: MCPRequest) -> MCPResponse
 where
     T: AbstractMCPServer,
 {
-    let id = request.id.as_str();
+    let id = &request.id;
     let mut result = json!({
         "protocolVersion": "2024-11-05",
         "capabilities": {
@@ -28,7 +28,7 @@ where
         serde_json::to_value(server.get_server_info()).unwrap(),
     );
 
-    MCPResponse::new(id.to_string(), Some(result), None)
+    MCPResponse::new(id.clone(), Some(result), None)
 }
 
 /**
@@ -38,7 +38,7 @@ pub fn process_tools_list<T>(server: &mut T, request: MCPRequest) -> MCPResponse
 where
     T: AbstractMCPServer,
 {
-    let id = request.id.as_str();
+    let id = &request.id;
     let tools_list: Vec<Value> = server
         .get_tools_list()
         .into_iter()
@@ -47,7 +47,7 @@ where
     let mut result_map = serde_json::Map::new();
     result_map.insert("tools".to_string(), Value::Array(tools_list));
     let result = Value::Object(result_map);
-    MCPResponse::new(id.to_string(), Some(result), None)
+    MCPResponse::new(id.clone(), Some(result), None)
 }
 
 /**
@@ -57,7 +57,7 @@ pub fn process_tools_call<T>(server: &mut T, mut request: MCPRequest) -> MCPResp
 where
     T: AbstractMCPServer,
 {
-    let id = request.id.as_str();
+    let id = &request.id;
     let params_value = request.params.take();
     let params = match params_value {
         Some(p) => match p.as_object() {
@@ -88,7 +88,7 @@ where
     let args = params.get("arguments").and_then(|v| v.as_object());
     let response_content = server.on_tool_call(name, args);
     MCPResponse::new(
-        id.to_string(),
+        id.clone(),
         Some(json!({
             "content": [{"type": "text", "text": response_content}]
         })),
@@ -96,9 +96,9 @@ where
     )
 }
 
-fn invalid_params_error_response(id: &str, message: String) -> MCPResponse {
+fn invalid_params_error_response(id: &Value, message: String) -> MCPResponse {
     MCPResponse::new(
-        id.to_string(),
+        id.clone(),
         None,
         Some(json!({
             "code": -32603,
@@ -107,9 +107,9 @@ fn invalid_params_error_response(id: &str, message: String) -> MCPResponse {
     )
 }
 
-pub fn invalid_request(id: &str, message: String) -> MCPResponse {
+pub fn invalid_request(id: &Value, message: String) -> MCPResponse {
     MCPResponse::new(
-        id.to_string(),
+        id.clone(),
         None,
         Some(json!({
             "code":-32600,

--- a/nah_server/src/process_routine.rs
+++ b/nah_server/src/process_routine.rs
@@ -14,7 +14,7 @@ pub fn process_initialize<T>(server: &mut T, request: MCPRequest) -> MCPResponse
 where
     T: AbstractMCPServer,
 {
-    let id = &request.id;
+    let id = request.id;
     let mut result = json!({
         "protocolVersion": "2024-11-05",
         "capabilities": {


### PR DESCRIPTION
Using `serde_json::Value` for id fields in both mcp request/response objects to support strings and numbers. This PR unblocks the official MCP inspector and other MCP clients from using the server.