### PR TITLE
Basic resource support in the server

### DIFF
--- a/example_server/src/main.rs
+++ b/example_server/src/main.rs
@@ -1,7 +1,7 @@
 /* This file is released in the public domain.
  */
+use nah_mcp_types::{MCPResourceDefinition, MCPToolDefinition};
 use nah_server::*;
-use nah_mcp_types::MCPToolDefinition;
 use serde_json::{json, Value};
 
 struct ExampleServer {}
@@ -10,7 +10,7 @@ impl AbstractMCPServer for ExampleServer {
     fn get_server_info(&self) -> ServerInfo {
         ServerInfo {
             name: "example-server".to_string(),
-            version: "0.1.0".to_string()
+            version: "0.1.0".to_string(),
         }
     }
 
@@ -24,12 +24,26 @@ impl AbstractMCPServer for ExampleServer {
                     "bar": {"type": "string"}
                 }
             }),
-            annotations: None
+            annotations: None,
         }]
     }
 
-    fn on_tool_call(&mut self, name: &str, args: Option<&serde_json::Map<String, Value>>) -> String {
+    fn on_tool_call(
+        &mut self,
+        name: &str,
+        args: Option<&serde_json::Map<String, Value>>,
+    ) -> String {
         "I don't know what you are requesting because I'm only an example.".to_string()
+    }
+
+    fn get_resources_list(&self) -> Vec<MCPResourceDefinition> {
+        vec![MCPResourceDefinition::direct_resource(
+            "files://text".to_string(),
+            "text".to_string(),
+            Some("A text file".to_string()),
+            None,
+            None,
+        )]
     }
 }
 

--- a/example_server/src/main.rs
+++ b/example_server/src/main.rs
@@ -1,6 +1,6 @@
 /* This file is released in the public domain.
  */
-use nah_mcp_types::{MCPResourceDefinition, MCPToolDefinition};
+use nah_mcp_types::{MCPResourceContent, MCPResourceDefinition, MCPToolDefinition};
 use nah_server::*;
 use serde_json::{json, Value};
 
@@ -30,8 +30,8 @@ impl AbstractMCPServer for ExampleServer {
 
     fn on_tool_call(
         &mut self,
-        name: &str,
-        args: Option<&serde_json::Map<String, Value>>,
+        _name: &str,
+        _args: Option<&serde_json::Map<String, Value>>,
     ) -> String {
         "I don't know what you are requesting because I'm only an example.".to_string()
     }
@@ -44,6 +44,16 @@ impl AbstractMCPServer for ExampleServer {
             None,
             None,
         )]
+    }
+
+    fn on_resources_read(&self, uri: &str) -> Vec<MCPResourceContent> {
+        let content = format!("Text file: {}", uri);
+        vec![MCPResourceContent {
+            uri: uri.to_string(),
+            text: Some(content),
+            mime: None,
+            blob: None,
+        }]
     }
 }
 

--- a/nah_mcp_types/src/lib.rs
+++ b/nah_mcp_types/src/lib.rs
@@ -97,16 +97,54 @@ impl MCPToolDefinition {
 /**
  * Describe a MCP Resource.
  */
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MCPResourceDefinition {
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub uri: Option<String>,
   #[serde(rename = "uriTemplate", skip_serializing_if = "Option::is_none")]
   pub uri_template: Option<String>,
   pub name: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub description: Option<String>,
   #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
   pub mime_type: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub size: Option<usize>,
+}
+
+impl MCPResourceDefinition {
+  /**
+   * Whether this resource definition is valid.
+   */
+  pub fn is_valid_resource_definition(&self) -> bool {
+    if self.uri.is_none() && self.uri_template.is_none() {
+      return false;
+    }
+    if self.uri.is_some() && self.uri_template.is_some() {
+      return false;
+    }
+    if self.uri_template.is_some() && self.size.is_some() {
+      return false;
+    }
+    return true;
+  }
+
+  pub fn direct_resource(
+    uri: String,
+    name: String,
+    description: Option<String>,
+    mime_type: Option<String>,
+    size: Option<usize>,
+  ) -> MCPResourceDefinition {
+    MCPResourceDefinition {
+      uri: Some(uri),
+      name,
+      description,
+      mime_type,
+      size,
+      uri_template: None,
+    }
+  }
 }
 
 /**

--- a/nah_server/src/lib.rs
+++ b/nah_server/src/lib.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use nah_mcp_types::MCPToolDefinition;
+use nah_mcp_types::{MCPResourceDefinition, MCPToolDefinition};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -44,4 +44,9 @@ pub trait AbstractMCPServer {
      */
     fn on_tool_call(&mut self, name: &str, args: Option<&serde_json::Map<String, Value>>)
         -> String;
+
+    /**
+     * Return a Vec of all resource definitions.
+     */
+    fn get_resources_list(&self) -> Vec<MCPResourceDefinition>;
 }

--- a/nah_server/src/lib.rs
+++ b/nah_server/src/lib.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use nah_mcp_types::{MCPResourceDefinition, MCPToolDefinition};
+use nah_mcp_types::{MCPResourceContent, MCPResourceDefinition, MCPToolDefinition};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -49,4 +49,12 @@ pub trait AbstractMCPServer {
      * Return a Vec of all resource definitions.
      */
     fn get_resources_list(&self) -> Vec<MCPResourceDefinition>;
+
+    /**
+     * Respond to the resource read requests. Return a list of resource contents.
+     *
+     * Args:
+     * * `uri`: the request URI
+     */
+    fn on_resources_read(&self, uri: &str) -> Vec<MCPResourceContent>;
 }

--- a/nah_server/src/process_routine.rs
+++ b/nah_server/src/process_routine.rs
@@ -122,6 +122,30 @@ where
 }
 
 /**
+ * Process resources/templates/list request.
+ */
+pub fn process_resources_templates_list<T>(server: &mut T, request: MCPRequest) -> MCPResponse
+where
+    T: AbstractMCPServer,
+{
+    let id = &request.id;
+    let resources_list: Vec<Value> = server
+        .get_resources_list()
+        .into_iter()
+        .filter(|v| v.uri_template.is_some())
+        .filter(|v| v.is_valid_resource_definition())
+        .map(|v| serde_json::to_value(v).unwrap())
+        .collect();
+    let mut result_map = serde_json::Map::new();
+    result_map.insert(
+        "resourceTemplates".to_string(),
+        Value::Array(resources_list),
+    );
+    let result = Value::Object(result_map);
+    MCPResponse::new(id.clone(), Some(result), None)
+}
+
+/**
  * Process resources/read request.
  */
 pub fn process_resources_read<T>(server: &mut T, request: MCPRequest) -> MCPResponse

--- a/nah_server/src/stdio_server.rs
+++ b/nah_server/src/stdio_server.rs
@@ -5,7 +5,8 @@
  */
 
 use crate::process_routine::{
-    invalid_request, process_initialize, process_tools_call, process_tools_list,
+    invalid_request, process_initialize, process_resources_list, process_tools_call,
+    process_tools_list,
 };
 use crate::AbstractMCPServer;
 use nah_mcp_types::request::MCPRequest;
@@ -51,6 +52,7 @@ where
             "initialize" => process_initialize(server, request),
             "tools/list" => process_tools_list(server, request),
             "tools/call" => process_tools_call(server, request),
+            "resources/list" => process_resources_list(server, request),
             _ => invalid_request(&request.id, format!("Unknown method: {}", request.method)),
         };
         send_response(response)?;

--- a/nah_server/src/stdio_server.rs
+++ b/nah_server/src/stdio_server.rs
@@ -6,7 +6,7 @@
 
 use crate::process_routine::{
     invalid_request, process_initialize, process_resources_list, process_resources_read,
-    process_tools_call, process_tools_list,
+    process_resources_templates_list, process_tools_call, process_tools_list,
 };
 use crate::AbstractMCPServer;
 use nah_mcp_types::request::MCPRequest;
@@ -53,6 +53,7 @@ where
             "tools/list" => process_tools_list(server, request),
             "tools/call" => process_tools_call(server, request),
             "resources/list" => process_resources_list(server, request),
+            "resources/templates/list" => process_resources_templates_list(server, request),
             "resources/read" => process_resources_read(server, request),
             _ => invalid_request(&request.id, format!("Unknown method: {}", request.method)),
         };

--- a/nah_server/src/stdio_server.rs
+++ b/nah_server/src/stdio_server.rs
@@ -5,8 +5,8 @@
  */
 
 use crate::process_routine::{
-    invalid_request, process_initialize, process_resources_list, process_tools_call,
-    process_tools_list,
+    invalid_request, process_initialize, process_resources_list, process_resources_read,
+    process_tools_call, process_tools_list,
 };
 use crate::AbstractMCPServer;
 use nah_mcp_types::request::MCPRequest;
@@ -53,6 +53,7 @@ where
             "tools/list" => process_tools_list(server, request),
             "tools/call" => process_tools_call(server, request),
             "resources/list" => process_resources_list(server, request),
+            "resources/read" => process_resources_read(server, request),
             _ => invalid_request(&request.id, format!("Unknown method: {}", request.method)),
         };
         send_response(response)?;


### PR DESCRIPTION
The following MCP requests are supported in `nah_server`:
* `resources/list`
* `resources/templates/list`
* `resources/read`