### PR TITLE
Add timeout_ms config field for mcp servers

### DIFF
--- a/nah/examples/weather/config.json
+++ b/nah/examples/weather/config.json
@@ -7,7 +7,8 @@
 		        "/ABSOLUTE/PATH/TO/PARENT/FOLDER/weather",
                 "run",
                 "weather.py"
-            ]
+            ],
+            "timeout_ms": 1000
 	}
     },
     "model": {

--- a/nah/src/mcp/http_server.rs
+++ b/nah/src/mcp/http_server.rs
@@ -18,6 +18,7 @@ use tokio::runtime::{Builder, Runtime};
 pub struct MCPRemoteServerConfig {
   pub url: String,
   pub headers: HashMap<String, String>,
+  pub timeout_ms: Option<u64>,
 }
 
 pub struct MCPHTTPServerConnection {
@@ -254,6 +255,9 @@ impl MCPHTTPServerConnection {
       prompt_cache: HashMap::new(),
       session_id: None,
     };
+    if config.timeout_ms.is_some() {
+      conn.set_timeout(config.timeout_ms.unwrap());
+    }
     let initialize_request = MCPRequest::initialize(
       &Value::String(uuid::Uuid::new_v4().to_string()),
       "nah",

--- a/nah/src/mcp/local_server.rs
+++ b/nah/src/mcp/local_server.rs
@@ -30,6 +30,7 @@ pub use notification::MCPNotification;
 pub struct MCPLocalServerCommand {
   pub command: String,
   pub args: Vec<String>,
+  pub timeout_ms: Option<u64>,
 }
 /**
  * Wrapper of a MCP local server process.
@@ -151,6 +152,8 @@ impl MCPLocalServerProcess {
     mcp_command: &MCPLocalServerCommand,
     history_path: &PathBuf,
   ) -> Result<Self, NahError> {
+    // Default 5000ms timeout
+    let timeout_ms = mcp_command.timeout_ms.unwrap_or(5000);
     let mut server_command = Command::new(&mcp_command.command);
     for arg in mcp_command.args.iter() {
       server_command.arg(&arg);
@@ -217,7 +220,7 @@ impl MCPLocalServerProcess {
       tool_cache: HashMap::new(),
       resource_cache: HashMap::new(),
       prompt_cache: HashMap::new(),
-      timeout_ms: 5000,
+      timeout_ms,
       history_file,
     };
 


### PR DESCRIPTION
Each MCP Server config has a new optional field of `timeout_ms` to control the timeout.