### PR TITLE
Accept iteratable parameters for chat apis

### DIFF
--- a/nah_chat/CHANGELOG
+++ b/nah_chat/CHANGELOG
@@ -1,0 +1,10 @@
+CHANGELOG of nah_chat
+===
+
+## v0.2.0
+* Accept `IntoIteratable` types of `ChatMessage` and parameters instead of `Vec` and `HashMap`.
+
+## v0.1.0
+Initial publish.
+* Async stream based chat completion API.
+* Chat related data structures.

--- a/nah_chat/Cargo.toml
+++ b/nah_chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nah_chat"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MPL-2.0"
 description = "Lightweight LLM chat completion API."


### PR DESCRIPTION
As title.
```
   messages: &Vec<ChatMessage>,    
   params: &HashMap<String, Value>,
```
Are changed into 
```
    messages: M,
    params: P,
  where
    P: IntoIterator<Item = (&'a String, &'a Value)>,
    M: IntoIterator<Item = &'b ChatMessage>,
```

So that we can support more data types as input. As a big change, bump the version of `nah_chat` to v0.2.0