### PR TITLE
[lib-chat] Enhance error handling and message formatting

### DIFF
--- a/nah/src/types.rs
+++ b/nah/src/types.rs
@@ -19,7 +19,11 @@ impl std::fmt::Display for NahError {
         write!(f, "NahError {}: {}", self.code, self.message)
       }
       Some(e) => {
-        write!(f, "NahError {}: {}, source: {}", self.code, self.message, e)
+        write!(
+          f,
+          "NahError {}: {}\ncaused by {}",
+          self.code, self.message, e
+        )
       }
     }
   }

--- a/nah_chat/src/error.rs
+++ b/nah_chat/src/error.rs
@@ -5,6 +5,7 @@
  */
 
 /// Error and related types.
+use reqwest;
 
 /**
  * Error kinds that may occur in `nah_chat`.
@@ -46,13 +47,36 @@ impl std::error::Error for Error {
 
 impl std::fmt::Display for Error {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(
-      f,
-      "{}: {}",
-      self.kind,
-      self.message.clone().unwrap_or("None".to_string()),
-    )
+    match &self.cause {
+      None => {
+        write!(
+          f,
+          "{}: {}",
+          self.kind,
+          self.message.clone().unwrap_or("None".to_string()),
+        )
+      }
+      Some(cause) => {
+        write!(
+          f,
+          "{}: {}\ncaused by {}",
+          self.kind,
+          self.message.clone().unwrap_or("None".to_string()),
+          cause
+        )
+      }
+    }
   }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<reqwest::Error> for Error {
+  fn from(error: reqwest::Error) -> Self {
+    Error {
+      kind: ErrorKind::NetworkError,
+      message: None,
+      cause: Some(Box::new(error)),
+    }
+  }
+}

--- a/nah_chat/src/error.rs
+++ b/nah_chat/src/error.rs
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/// Error and related types.
+
+/**
+ * Error kinds that may occur in `nah_chat`.
+ */
+#[derive(Debug)]
+pub enum ErrorKind {
+  NetworkError,
+  ModelServerError,
+}
+
+impl std::fmt::Display for ErrorKind {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      ErrorKind::NetworkError => {
+        write!(f, "Network error")
+      }
+      ErrorKind::ModelServerError => {
+        write!(f, "Model server error")
+      }
+    }
+  }
+}
+
+/**
+ * Error type of `nah_chat`.
+ */
+#[derive(Debug)]
+pub struct Error {
+  pub kind: ErrorKind,
+  pub message: Option<String>,
+  pub cause: Option<Box<dyn std::error::Error>>,
+}
+
+impl std::error::Error for Error {
+  fn cause(&self) -> Option<&dyn std::error::Error> {
+    self.cause.as_ref().and_then(|e| Some(e.as_ref()))
+  }
+}
+
+impl std::fmt::Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "{}: {}",
+      self.kind,
+      self.message.clone().unwrap_or("None".to_string()),
+    )
+  }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/nah_chat/src/lib.rs
+++ b/nah_chat/src/lib.rs
@@ -57,62 +57,14 @@
 //! This is a part of [nah](https://github.com/linmx0130/nah) project. `nah` means "*N*ot *A*
 //! *H*uman". Source code is available under [MPL-2.0](https://mozilla.org/MPL/2.0/).
 //!
+mod error;
+
 use async_stream::stream;
 use bytes::Bytes;
+pub use error::{Error, ErrorKind, Result};
 use futures_core::stream::Stream;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value, json};
-
-/**
- * Error kinds that may occur in `nah_chat`.
- */
-#[derive(Debug)]
-pub enum ErrorKind {
-  NetworkError,
-  ModelServerError,
-}
-
-impl std::fmt::Display for ErrorKind {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      ErrorKind::NetworkError => {
-        write!(f, "Network error")
-      }
-      ErrorKind::ModelServerError => {
-        write!(f, "Model server error")
-      }
-    }
-  }
-}
-
-/**
- * Error type of `nah_chat`.
- */
-#[derive(Debug)]
-pub struct Error {
-  kind: ErrorKind,
-  message: Option<String>,
-  cause: Option<Box<dyn std::error::Error>>,
-}
-
-impl std::error::Error for Error {
-  fn cause(&self) -> Option<&dyn std::error::Error> {
-    self.cause.as_ref().and_then(|e| Some(e.as_ref()))
-  }
-}
-
-impl std::fmt::Display for Error {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(
-      f,
-      "{}: {}",
-      self.kind,
-      self.message.clone().unwrap_or("None".to_string()),
-    )
-  }
-}
-
-pub type Result<T> = std::result::Result<T, Error>;
 
 /**
  * Data structure of a chat message, could be from the user, the assistant or the tool.


### PR DESCRIPTION
0. Move error types in nah_chat to an independent file.
1. Improves error message readability by using "caused by" instead of "source"
2. Adds automatic conversion of reqwest errors to nah_chat custom Error type
3. Simplifies network error handling code using Rust's try operator (?)
4. Updates error formatting to display causes when present