### PR TITLE
Rename max_token to max_tokens in builder method

### DIFF
--- a/nah/src/chat.rs
+++ b/nah/src/chat.rs
@@ -199,7 +199,7 @@ impl ChatContext {
   pub fn generate(&mut self) -> Result<&ChatMessage, NahError> {
     let mut params_builder = ChatCompletionParamsBuilder::new();
     params_builder
-      .max_token(4096)
+      .max_tokens(4096)
       .temperature(0.7)
       .top_p(0.9)
       .frequency_penalty(0.5)

--- a/nah_chat/src/lib.rs
+++ b/nah_chat/src/lib.rs
@@ -262,9 +262,9 @@ impl ChatCompletionParamsBuilder {
   /**
    * Set max token parameter.
    */
-  pub fn max_token(&mut self, n: usize) -> &mut Self {
+  pub fn max_tokens(&mut self, n: usize) -> &mut Self {
     self.data.insert(
-      "max_token".to_owned(),
+      "max_tokens".to_owned(),
       Value::Number(Number::from_u128(n as u128).unwrap()),
     );
     self

--- a/nah_chat/src/tests.rs
+++ b/nah_chat/src/tests.rs
@@ -84,12 +84,12 @@ fn test_apply_tool_calls() {
 #[test]
 fn test_chat_completion_params_builder() {
   let mut params_builder = ChatCompletionParamsBuilder::new();
-  params_builder.temperature(0.7).top_p(0.9).max_token(10000);
+  params_builder.temperature(0.7).top_p(0.9).max_tokens(10000);
   params_builder.insert("customized_key", json!("customized_value"));
   let params = params_builder.build();
   assert_eq!(params["temperature"], 0.7);
   assert_eq!(params["top_p"], 0.9);
-  assert_eq!(params["max_token"], 10000);
+  assert_eq!(params["max_tokens"], 10000);
   assert_eq!(params["customized_key"], "customized_value");
   assert_eq!(params.len(), 4);
 }


### PR DESCRIPTION
- JSON payload key changed from `max_token` to `max_tokens`
- Updated callers to match the new builder API