### PR TITLE
Image content support

### DIFF
--- a/nah/src/chat.rs
+++ b/nah/src/chat.rs
@@ -17,7 +17,9 @@ use crate::AppContext;
 use crate::ModelConfig;
 use futures_util::pin_mut;
 use futures_util::stream::StreamExt;
-use nah_chat::{ChatClient, ChatCompletionParamsBuilder, ChatMessage, ToolCallRequest};
+use nah_chat::{
+  ChatClient, ChatCompletionParamsBuilder, ChatMessage, ChatMessageContentValue, ToolCallRequest,
+};
 use serde_json::{json, Value};
 use std::fs::{File, OpenOptions};
 use tokio::runtime::{Builder, Runtime};
@@ -72,7 +74,7 @@ pub fn process_chat(context: &mut AppContext) {
     .and_then(|sys| {
       chat_context.messages.push(ChatMessage {
         role: "system".to_string(),
-        content: sys.to_string(),
+        content: ChatMessageContentValue::Text(sys.to_string()),
         reasoning_content: None,
         tool_call_id: None,
         tool_calls: None,
@@ -186,7 +188,7 @@ impl ChatContext {
   pub fn user_message(&mut self, message: String) {
     self.push_message(ChatMessage {
       role: "user".to_string(),
-      content: message,
+      content: ChatMessageContentValue::Text(message),
       reasoning_content: None,
       tool_call_id: None,
       tool_calls: None,
@@ -324,7 +326,7 @@ impl ChatContext {
         println!("[Tool: {}]: {}", server_name, text_content);
         tool_call_responses.push(ChatMessage {
           role: "tool".to_owned(),
-          content: text_content,
+          content: ChatMessageContentValue::Text(text_content),
           reasoning_content: None,
           tool_call_id: Some(item.id.to_owned()),
           tool_calls: None,

--- a/nah_chat/Cargo.toml
+++ b/nah_chat/Cargo.toml
@@ -17,3 +17,6 @@ reqwest = { version = "0.12.22"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = "0.3.31"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "net", "macros"] }

--- a/nah_chat/Cargo.toml
+++ b/nah_chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nah_chat"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = "MPL-2.0"
 description = "Lightweight LLM chat completion API."

--- a/nah_chat/examples/calorie.rs
+++ b/nah_chat/examples/calorie.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use futures_util::{StreamExt, pin_mut};
 use nah_chat::{ChatClient, ChatMessage, ChatMessageContentValue, TypedChatMessageContent};
 use std::collections::HashMap;
 use std::io;
@@ -31,27 +30,10 @@ async fn main() -> io::Result<()> {
     tool_calls: None,
   }];
   let params = HashMap::new();
-  let stream = chat_client
-    .chat_completion_stream(&model_name, &messages, &params)
+  let message = chat_client
+    .chat_completion(&model_name, &messages, &params)
     .await
     .unwrap();
-  pin_mut!(stream);
-
-  // buffer for the new message
-  let mut message = ChatMessage::new();
-
-  // consume the stream
-  while let Some(delta_result) = stream.next().await {
-    match delta_result {
-      Ok(delta) => {
-        println!("{:?}", delta);
-        message.apply_model_response_chunk(delta);
-      }
-      Err(e) => {
-        eprintln!("Error occurred while processing the chat completion: {}", e);
-      }
-    }
-  }
   println!("{}", message.content);
   Ok(())
 }

--- a/nah_chat/examples/calorie.rs
+++ b/nah_chat/examples/calorie.rs
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use futures_util::{StreamExt, pin_mut};
+use nah_chat::{ChatClient, ChatMessage, ChatMessageContentValue, TypedChatMessageContent};
+use std::collections::HashMap;
+use std::io;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> io::Result<()> {
+  let base_url = std::env::var("BASE_URL").unwrap();
+  let auth_token = std::env::var("AUTH_TOKEN").unwrap();
+  let model_name = std::env::var("MODEL").unwrap();
+
+  let chat_client = ChatClient::init(base_url, Some(auth_token));
+  let messages = vec![ChatMessage {
+    role: "user".to_owned(),
+    content: ChatMessageContentValue::TypedContentList(vec![
+      TypedChatMessageContent::image_url_content(
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ad/Katsudon_001.jpg/330px-Katsudon_001.jpg",
+      ),
+      TypedChatMessageContent::text_content(
+        "Try to figure out the calorie value of this meal. The answer may not be very accurate, but should be informative.",
+      ),
+    ]),
+    reasoning_content: None,
+    tool_call_id: None,
+    tool_calls: None,
+  }];
+  let params = HashMap::new();
+  let stream = chat_client
+    .chat_completion_stream(&model_name, &messages, &params)
+    .await
+    .unwrap();
+  pin_mut!(stream);
+
+  // buffer for the new message
+  let mut message = ChatMessage::new();
+
+  // consume the stream
+  while let Some(delta_result) = stream.next().await {
+    match delta_result {
+      Ok(delta) => {
+        println!("{:?}", delta);
+        message.apply_model_response_chunk(delta);
+      }
+      Err(e) => {
+        eprintln!("Error occurred while processing the chat completion: {}", e);
+      }
+    }
+  }
+  println!("{}", message.content);
+  Ok(())
+}

--- a/nah_chat/src/error.rs
+++ b/nah_chat/src/error.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/// Error and related types.
-use reqwest;
+//! Error and related types.
 
 /**
  * Error kinds that may occur in `nah_chat`.
@@ -41,7 +40,7 @@ pub struct Error {
 
 impl std::error::Error for Error {
   fn cause(&self) -> Option<&dyn std::error::Error> {
-    self.cause.as_ref().and_then(|e| Some(e.as_ref()))
+    self.cause.as_ref().map(|e| e.as_ref())
   }
 }
 

--- a/nah_chat/src/lib.rs
+++ b/nah_chat/src/lib.rs
@@ -272,7 +272,7 @@ impl ChatClient {
             Err(e) => {
                 yield Err(Error {
                     kind: ErrorKind::ModelServerError,
-                    message: Some(format!("Failed to decode model server response")),
+                    message: Some("Failed to decode model server response".to_string()),
                     cause: Some(Box::new(e))
                 });
                 return;
@@ -315,7 +315,7 @@ impl ChatClient {
       .as_object()
       .and_then(|chunk| chunk.get("choices"))
       .and_then(|choices_value| choices_value.as_array())
-      .and_then(|choices_arr| choices_arr.get(0))
+      .and_then(|choices_arr| choices_arr.first())
       .and_then(|choice_value| choice_value.as_object())
       .and_then(|choice_obj| choice_obj.get("delta"));
 

--- a/nah_chat/src/lib.rs
+++ b/nah_chat/src/lib.rs
@@ -174,8 +174,8 @@ impl ChatClient {
   pub fn init(base_url: String, auth_token: Option<String>) -> Self {
     let client = reqwest::Client::new();
     ChatClient {
-      base_url: base_url,
-      auth_token: auth_token,
+      base_url,
+      auth_token,
       http_client: client,
     }
   }
@@ -245,31 +245,38 @@ impl ChatClient {
   {
     let req = self.create_chat_completion_request(model, messages, false, params);
     let res_text = req.send().await?.text().await?;
-    let response_data: Value = serde_json::from_str(&res_text).map_err(|e| Error {
+    let mut response_data: Value = serde_json::from_str(&res_text).map_err(|e| Error {
       kind: ErrorKind::ModelServerError,
       message: Some("Failed to parse model server response".to_string()),
       cause: Some(Box::new(e)),
     })?;
-    let choice = response_data
-      .get("choices")
-      .and_then(|choices| choices.as_array())
-      .and_then(|choices| choices.first())
+    let mut choices = response_data
+      .as_object_mut()
+      .and_then(|obj| obj.remove("choices"))
       .ok_or(Error {
         kind: ErrorKind::ModelServerError,
-        message: Some("Invalid response format: missing choices".to_string()),
+        message: Some("Invalid response format: missing choices field".to_string()),
+        cause: None,
+      })?;
+    let choice: &mut Value = choices
+      .as_array_mut()
+      .and_then(|choices| choices.first_mut())
+      .ok_or(Error {
+        kind: ErrorKind::ModelServerError,
+        message: Some("Invalid response format: missing choices item".to_string()),
         cause: None,
       })?;
 
     let message_value: Value = choice
-      .get("message")
+      .as_object_mut()
+      .and_then(|choice| choice.remove("message"))
       .ok_or(Error {
         kind: ErrorKind::ModelServerError,
         message: Some("Invalid response format: missing message".to_string()),
         cause: None,
-      })?
-      .clone();
+      })?;
 
-    let message: ChatMessage = match serde_json::from_value(message_value.clone()) {
+    let message: ChatMessage = match serde_json::from_value(message_value) {
       Ok(m) => m,
       Err(e) => {
         return Err(Error {

--- a/nah_chat/src/lib.rs
+++ b/nah_chat/src/lib.rs
@@ -225,6 +225,62 @@ impl ChatClient {
 
     req
   }
+  /**
+   * Request chat completion in the non-stream approach.
+   *
+   * Args:
+   * * `model` Name of the model to be called.
+   * * `messages` An list of [ChatMessage] as the context.
+   * * `params` Other parameters to be sent.
+   */
+  pub async fn chat_completion<'a, 'b, P, M>(
+    &self,
+    model: &str,
+    messages: M,
+    params: P,
+  ) -> Result<ChatMessage>
+  where
+    P: IntoIterator<Item = (&'a String, &'a Value)>,
+    M: IntoIterator<Item = &'b ChatMessage>,
+  {
+    let req = self.create_chat_completion_request(model, messages, false, params);
+    let res_text = req.send().await?.text().await?;
+    let response_data: Value = serde_json::from_str(&res_text).map_err(|e| Error {
+      kind: ErrorKind::ModelServerError,
+      message: Some("Failed to parse model server response".to_string()),
+      cause: Some(Box::new(e)),
+    })?;
+    let choice = response_data
+      .get("choices")
+      .and_then(|choices| choices.as_array())
+      .and_then(|choices| choices.first())
+      .ok_or(Error {
+        kind: ErrorKind::ModelServerError,
+        message: Some("Invalid response format: missing choices".to_string()),
+        cause: None,
+      })?;
+
+    let message_value: Value = choice
+      .get("message")
+      .ok_or(Error {
+        kind: ErrorKind::ModelServerError,
+        message: Some("Invalid response format: missing message".to_string()),
+        cause: None,
+      })?
+      .clone();
+
+    let message: ChatMessage = match serde_json::from_value(message_value.clone()) {
+      Ok(m) => m,
+      Err(e) => {
+        return Err(Error {
+          kind: ErrorKind::ModelServerError,
+          message: Some("Failed to parse message from response".to_string()),
+          cause: Some(Box::new(e)),
+        });
+      }
+    };
+    Ok(message)
+  }
 
   /**
    * Request chat completion in the async stream approach.

--- a/nah_chat/src/lib.rs
+++ b/nah_chat/src/lib.rs
@@ -206,7 +206,6 @@ impl ChatClient {
         "stream": is_stream,
         "n": 1,
     });
-
     params.into_iter().for_each(|(key, value)| {
       data
         .as_object_mut()

--- a/nah_chat/src/message.rs
+++ b/nah_chat/src/message.rs
@@ -27,6 +27,26 @@ pub struct TypedChatMessageContent {
   pub image_url: Option<URLObject>,
 }
 
+impl TypedChatMessageContent {
+  pub fn text_content(text: &str) -> TypedChatMessageContent {
+    TypedChatMessageContent {
+      data_type: "text".to_owned(),
+      text: Some(text.to_owned()),
+      image_url: None,
+    }
+  }
+
+  pub fn image_url_content(image_url: &str) -> TypedChatMessageContent {
+    TypedChatMessageContent {
+      data_type: "image_url".to_owned(),
+      text: None,
+      image_url: Some(URLObject {
+        url: image_url.to_owned(),
+      }),
+    }
+  }
+}
+
 /**
  * Type for message contents.
  *
@@ -36,21 +56,25 @@ pub struct TypedChatMessageContent {
 #[serde(untagged)]
 pub enum ChatMessageContentValue {
   Text(String),
-  TypedContent(TypedChatMessageContent),
+  TypedContentList(Vec<TypedChatMessageContent>),
 }
 
 impl std::fmt::Display for ChatMessageContentValue {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       ChatMessageContentValue::Text(text) => write!(f, "{}", text),
-      ChatMessageContentValue::TypedContent(typed_content) => {
-        if let Some(text) = &typed_content.text {
-          write!(f, "{text}")
-        } else if let Some(image_url) = &typed_content.image_url {
-          write!(f, "[Image URL: {}]", image_url.url)
-        } else {
-          write!(f, "[Unknown type: {}]", typed_content.data_type)
+      ChatMessageContentValue::TypedContentList(typed_content_list) => {
+        let mut buffer = String::new();
+        for typed_content in typed_content_list {
+          if let Some(text) = &typed_content.text {
+            buffer += text
+          } else if let Some(image_url) = &typed_content.image_url {
+            buffer += &format!("[Image URL: {}]", image_url.url);
+          } else {
+            buffer += &format!("[Unknown type: {}]", typed_content.data_type);
+          }
         }
+        write!(f, "{}", buffer)
       }
     }
   }
@@ -101,6 +125,7 @@ impl ChatMessage {
       tool_calls: None,
     }
   }
+
   /**
    * Consume the chunk delta return from the chat completion stream API and apply it on to the message.
    */
@@ -172,6 +197,19 @@ impl ChatMessage {
       }
       Some(())
     });
+  }
+
+  /**
+   * Create a pure text user message.
+   */
+  pub fn user_text_message(text: &str) -> ChatMessage {
+    ChatMessage {
+      role: "user".to_owned(),
+      content: ChatMessageContentValue::Text(text.to_owned()),
+      reasoning_content: None,
+      tool_call_id: None,
+      tool_calls: None,
+    }
   }
 }
 

--- a/nah_chat/src/message.rs
+++ b/nah_chat/src/message.rs
@@ -4,6 +4,57 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 use serde::{Deserialize, Serialize};
+/**
+ * This is used to represent a URL in the message content. Currently, only
+ * images will be represented in this format.
+ */
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct URLObject {
+  pub url: String,
+}
+
+/**
+ * This is used to represent a message content that can have multiple types
+ * with a type annotation. Currently, it supports text and image_url.
+ */
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TypedChatMessageContent {
+  #[serde(rename = "type")]
+  pub data_type: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub text: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub image_url: Option<URLObject>,
+}
+
+/**
+ * Type for message contents.
+ *
+ * It can be either a text message or a `TypedChatMessageContent`.
+ */
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum ChatMessageContentValue {
+  Text(String),
+  TypedContent(TypedChatMessageContent),
+}
+
+impl std::fmt::Display for ChatMessageContentValue {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      ChatMessageContentValue::Text(text) => write!(f, "{}", text),
+      ChatMessageContentValue::TypedContent(typed_content) => {
+        if let Some(text) = &typed_content.text {
+          write!(f, "{text}")
+        } else if let Some(image_url) = &typed_content.image_url {
+          write!(f, "[Image URL: {}]", image_url.url)
+        } else {
+          write!(f, "[Unknown type: {}]", typed_content.data_type)
+        }
+      }
+    }
+  }
+}
 
 /**
  * Data structure of a chat message, could be from the user, the assistant or the tool.
@@ -12,8 +63,10 @@ use serde::{Deserialize, Serialize};
 pub struct ChatMessage {
   /** The role of the message. */
   pub role: String,
-  /** Text string content of the message */
-  pub content: String,
+
+  /** Content of the message */
+  pub content: ChatMessageContentValue,
+
   /** Reasoning content in string */
   #[serde(rename = "reasoningContent", skip_serializing_if = "Option::is_none")]
   pub reasoning_content: Option<String>,
@@ -22,8 +75,10 @@ pub struct ChatMessage {
    *
    * Only valid for messages with `role` of `"tool"`.
    */
+
   #[serde(skip_serializing_if = "Option::is_none")]
   pub tool_call_id: Option<String>,
+
   /**
    * The tool calls requested by the model.
    *
@@ -40,7 +95,7 @@ impl ChatMessage {
   pub fn new() -> Self {
     ChatMessage {
       role: String::new(),
-      content: String::new(),
+      content: ChatMessageContentValue::Text(String::new()),
       reasoning_content: None,
       tool_call_id: None,
       tool_calls: None,
@@ -55,7 +110,12 @@ impl ChatMessage {
       Some(())
     });
     chunk.content.and_then(|content| {
-      self.content.push_str(&content);
+      match &mut self.content {
+        ChatMessageContentValue::Text(t) => t.push_str(&content),
+        _ => {
+          // Cannot apply the chunk. Ignore.
+        }
+      }
       Some(())
     });
     chunk

--- a/nah_chat/src/tests.rs
+++ b/nah_chat/src/tests.rs
@@ -153,24 +153,24 @@ fn test_deserialize_text_content() {
 fn test_deserialize_image_url() {
   let data = r#"{
       "role": "user",
-      "content": {
+      "content": [{
         "type": "image_url",
         "image_url": {
           "url": "data:image/jpeg;base64"
         }
-      }
+      }]
     }
     "#;
   let message: ChatMessage = serde_json::from_str(data).unwrap();
   assert_eq!(message.role, "user");
   assert_eq!(
     message.content,
-    ChatMessageContentValue::TypedContent(TypedChatMessageContent {
+    ChatMessageContentValue::TypedContentList(vec![TypedChatMessageContent {
       data_type: "image_url".to_string(),
       image_url: Some(URLObject {
         url: "data:image/jpeg;base64".to_string()
       }),
       text: None
-    })
+    }])
   );
 }

--- a/nah_chat/src/tests.rs
+++ b/nah_chat/src/tests.rs
@@ -10,7 +10,7 @@ use super::*;
 fn test_apply_text_and_reasoning_content_chunk() {
   let mut message = ChatMessage {
     role: "assistant".to_owned(),
-    content: "A".to_owned(),
+    content: ChatMessageContentValue::Text("A".to_owned()),
     reasoning_content: None,
     tool_call_id: None,
     tool_calls: None,
@@ -24,7 +24,10 @@ fn test_apply_text_and_reasoning_content_chunk() {
   });
 
   assert_eq!(message.role, "assistant");
-  assert_eq!(message.content, "A test");
+  assert_eq!(
+    message.content,
+    ChatMessageContentValue::Text("A test".to_owned())
+  );
   assert_eq!(message.reasoning_content.unwrap(), "reason");
 }
 
@@ -32,7 +35,7 @@ fn test_apply_text_and_reasoning_content_chunk() {
 fn test_apply_tool_calls() {
   let mut message = ChatMessage {
     role: "assistant".to_owned(),
-    content: "A".to_owned(),
+    content: ChatMessageContentValue::Text("A".to_owned()),
     reasoning_content: None,
     tool_call_id: None,
     tool_calls: None,
@@ -124,6 +127,50 @@ fn test_collect_chat_response_chunk_delta() {
   ];
   let message: ChatMessage = delta.into_iter().collect();
   assert_eq!(message.role, "assistant");
-  assert_eq!(message.content, "good content generated");
+  assert_eq!(
+    message.content,
+    ChatMessageContentValue::Text("good content generated".to_owned())
+  );
   assert_eq!(message.reasoning_content, Some("think a bit".to_owned()));
+}
+
+#[test]
+fn test_deserialize_text_content() {
+  let data = r#"{
+      "role": "user",
+      "content": "Hello world"
+    }
+    "#;
+  let message: ChatMessage = serde_json::from_str(data).unwrap();
+  assert_eq!(message.role, "user");
+  assert_eq!(
+    message.content,
+    ChatMessageContentValue::Text("Hello world".to_string())
+  );
+}
+
+#[test]
+fn test_deserialize_image_url() {
+  let data = r#"{
+      "role": "user",
+      "content": {
+        "type": "image_url",
+        "image_url": {
+          "url": "data:image/jpeg;base64"
+        }
+      }
+    }
+    "#;
+  let message: ChatMessage = serde_json::from_str(data).unwrap();
+  assert_eq!(message.role, "user");
+  assert_eq!(
+    message.content,
+    ChatMessageContentValue::TypedContent(TypedChatMessageContent {
+      data_type: "image_url".to_string(),
+      image_url: Some(URLObject {
+        url: "data:image/jpeg;base64".to_string()
+      }),
+      text: None
+    })
+  );
 }


### PR DESCRIPTION
Changes to `nah_chat`:
- Add `ChatMessageContentValue`, and `TypedChatMessageContent` to support image contents.
- Add non-streaming `chat_completion` API.
- Bump version code to 0.6.0
- Add an example program.